### PR TITLE
Add millimeter entry, layout enhancements 

### DIFF
--- a/app.jsx
+++ b/app.jsx
@@ -39,6 +39,7 @@ Configurator = React.createClass({
   getInitialState: function() {
     return {
       paper: 'letter',
+      unit: 'inches',
       inside: 'none',
       height: 3.5,
       width: 2.5,
@@ -56,7 +57,11 @@ Configurator = React.createClass({
     props.forEach(function(prop) {
       var val = Number(this.state[prop]);
       if (val > 0) {
-        measurements[prop] = val;
+        if (this.state.unit == 'millimeters') {
+          measurements[prop] = val * 0.03937;
+        } else {
+          measurements[prop] = val;
+        }
       } else {
         hasInvalid = true;
       }
@@ -116,6 +121,9 @@ Configurator = React.createClass({
   paperChange: function(e) {
     this.changeState('paper', e.target.value)
   },
+  unitChange: function(e) {
+    this.changeState('unit', e.target.value)
+  },
   imageBoxFrontChange: function(e) {
     if (e.target.files) {
       var file = e.target.files[0];
@@ -134,94 +142,87 @@ Configurator = React.createClass({
     return (
       <form className="container configurator form-horizontal" onSubmit={this.handleSubmit}>
         <div className="form-group">
-          <label className="control-label">
-            <span className="col-xs-4">Paper Size</span>
-            <div className="col-xs-8">
-              <select
-                className="form-control" ref="paper"
-                onChange={this.paperChange} value={this.state.paper}
-              >
+          <label className="control-label col-xs-4">Paper Size</label>
+          <div className="col-xs-8">
+            <select
+              className="form-control" ref="paper"
+              onChange={this.paperChange} value={this.state.paper}
+			  >
                 <option value="letter">Letter</option>
                 <option value="a4">A4</option>
-              </select>
-            </div>
-          </label>
+            </select>
+          </div>
         </div>
         <div className="form-group">
-          <label className="control-label col-xs-offset-2 col-xs-10">
-            All measurements are in Inches
-          </label>
+          <label className="control-label col-xs-4">Unit</label>
+          <div className="col-xs-8">
+            <select
+              className="form-control" ref="paper"
+              onChange={this.unitChange} value={this.state.unit}
+			  >
+                <option value="inches">Inches</option>
+                <option value="millimeters">Millimeters</option>
+            </select>
+          </div>
         </div>
         <div className="form-group">
-          <label className="control-label">
-            <span className="col-xs-4">Card width</span>
-            <div className="col-xs-8">
-              <input
-                className="form-control" type="text" ref="width"
-                onChange={this.widthChange} value={this.state.width}
-              />
-            </div>
-          </label>
+          <label className="control-label col-xs-4">Card width</label>
+          <div className="col-xs-8">
+            <input
+              className="form-control" type="text" ref="width"
+              onChange={this.widthChange} value={this.state.width}
+            />
+          </div>
         </div>
         <div className="form-group">
-          <label className="control-label">
-            <span className="col-xs-4">Card height</span>
-            <div className="col-xs-8">
-              <input
-                className="form-control" type="text" ref="height"
-                onChange={this.heightChange} value={this.state.height}
-              />
-            </div>
-          </label>
+          <label className="control-label col-xs-4">Card height</label>
+          <div className="col-xs-8">
+            <input
+              className="form-control" type="text" ref="height"
+              onChange={this.heightChange} value={this.state.height}
+            />
+          </div>
         </div>
         <div className="form-group">
-          <label className="control-label">
-            <span className="col-xs-4">Box depth</span>
-            <div className="col-xs-8">
-              <input
-                className="form-control" type="text" ref="depth"
-                onChange={this.depthChange} value={this.state.depth}
-              />
-            </div>
-          </label>
+          <label className="control-label col-xs-4">Box depth</label>
+          <div className="col-xs-8">
+            <input
+              className="form-control" type="text" ref="depth"
+              onChange={this.depthChange} value={this.state.depth}
+            />
+          </div>
         </div>
         <div className="form-group">
-          <label className="control-label">
-            <span className="col-xs-4">Box Color</span>
-            <div className="col-xs-6">
-              <input
-                className="form-control" type="text" ref="depth"
-                onChange={this.colorChange} value={this.state.color}
-              />
-            </div>
-            <div className="col-xs-1" style={this.state.colorStyle}>&nbsp;</div>
-          </label>
+          <label className="control-label col-xs-4">Box Color</label>
+          <div className="col-xs-6">
+            <input
+              className="form-control" type="text" ref="depth"
+              onChange={this.colorChange} value={this.state.color}
+            />
+          </div>
+          <div className="col-xs-1" style={this.state.colorStyle}>&nbsp;</div>
         </div>
         <div className="form-group">
-          <label className="control-label">
-            <span className="col-xs-4">Drawer Style</span>
-            <div className="col-xs-8">
-              <select
-                className="form-control" ref="inside"
-                onChange={this.insideChange} value={this.state.inside}
-              >
-                <option value="tray">Tray</option>
-                <option value="sleeve">Sleeve</option>
-                <option value="none">None</option>
-              </select>
-            </div>
-          </label>
+          <label className="control-label col-xs-4">Drawer Style</label>
+          <div className="col-xs-8">
+            <select
+              className="form-control" ref="inside"
+              onChange={this.insideChange} value={this.state.inside}
+            >
+              <option value="tray">Tray</option>
+              <option value="sleeve">Sleeve</option>
+              <option value="none">None</option>
+            </select>
+          </div>
         </div>
         <div className="form-group">
-          <label className="control-label">
-            <span className="col-xs-4">Box Front</span>
-            <div className="col-xs-8">
-              <input
-                className="form-control" type="file" ref="imageBoxFront"
-                onChange={this.imageBoxFrontChange}
-              />
-            </div>
-          </label>
+          <label className="control-label col-xs-4">Box Front</label>
+          <div className="col-xs-8">
+            <input
+              className="form-control" type="file" ref="imageBoxFront"
+              onChange={this.imageBoxFrontChange}
+            />
+          </div>
         </div>
         <div className="form-group">
           <div className="col-xs-offset-4 col-xs-8">

--- a/app.jsx
+++ b/app.jsx
@@ -18,18 +18,24 @@ Window = React.createClass({
   },
   render: function() {
     return (
-      <div className="app">
-        <Configurator onRebuildPreview={this.generatePreview} onDownload={this.downloadPdf} />
-        <PreviewPane pdfBlob={this.state.pdfBlob}/>
-        <h3>
-          When you print, make sure you print at 100% size.
-        </h3>
-        <a href="https://github.com/andylei/paperbox">
-          <img style={{position: 'absolute', top: 0, right: 0, border: 0}}
+      <div className="app container">
+        <div className="row">
+          <h2>Tuckbox Generator</h2>
+          <hr />
+          <div className="col-xs-4">
+            <Configurator onRebuildPreview={this.generatePreview} onDownload={this.downloadPdf} />
+            </div>
+          <div className="col-xs-7">
+            <PreviewPane pdfBlob={this.state.pdfBlob}/>
+            <h3>When you print, make sure you print at 100% size.</h3>
+          </div>
+          <a href="https://github.com/andylei/paperbox">
+            <img style={{position: 'absolute', top: 0, right: 0, border: 0}}
                src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"
                alt="Fork me on Github"
-          />
-        </a>
+            />
+          </a>
+        </div>
       </div>
     );
   }
@@ -66,9 +72,9 @@ Configurator = React.createClass({
         hasInvalid = true;
       }
     }.bind(this));
-    var hexMatcher = /^[0-9a-f]{6}/i;
-    if (hexMatcher.test(this.state.color)) {
-      measurements.color = this.state.color;
+    var hexMatcher = /^#?([0-9a-f]{6})/i;
+    if ((matches = hexMatcher.exec(this.state.color))) {
+      measurements.color = matches[1];
     }
     if (!hasInvalid) {
       return measurements;
@@ -140,7 +146,7 @@ Configurator = React.createClass({
   },
   render: function() {
     return (
-      <form className="container configurator form-horizontal" onSubmit={this.handleSubmit}>
+      <form className="configurator form-horizontal" onSubmit={this.handleSubmit}>
         <div className="form-group">
           <label className="control-label col-xs-4">Paper Size</label>
           <div className="col-xs-8">
@@ -196,7 +202,7 @@ Configurator = React.createClass({
           <label className="control-label col-xs-4">Box Color</label>
           <div className="col-xs-6">
             <input
-              className="form-control" type="text" ref="depth"
+              className="form-control" type="color" ref="depth"
               onChange={this.colorChange} value={this.state.color}
             />
           </div>


### PR DESCRIPTION
Some small modifications that I thought would be useful:
- Add support for size entry in millimeters (with a dropdown toggle)
- Fix form layout (the whole input was wrapped in a label, causing the form fields to not be justified)
- Changed the look slightly using basic Bootstrap features
- Changed the color entry to use the 'color' input type, an [HTML 5 feature in Chrome and FF](http://caniuse.com/#feat=input-color)

![tb](https://cloud.githubusercontent.com/assets/556514/5990851/698fbd8c-a98c-11e4-9c44-925e49200c69.png)
